### PR TITLE
修复拼写错误

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复 `device.release` 字段拼写错误的问题 [#15](https://github.com/batu1579/hamibot-types/issues/15)
+
 ## [0.1.4] - 2023-04-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixed
 
 - 修复 `device.release` 字段拼写错误的问题 [#15](https://github.com/batu1579/hamibot-types/issues/15)
+- 修复 `classNameContains()` 和 `UiSelector.classNameContains()` 方法的拼写错误 [#16](https://github.com/batu1579/hamibot-types/issues/16)
+- 添加 `UiObject` 中遗漏的 `indexInParent()` 方法
 
 ## [0.1.4] - 2023-04-14
 

--- a/types/device.d.ts
+++ b/types/device.d.ts
@@ -2,8 +2,8 @@
  * @Author: BATU1579
  * @CreateDate: 2022-06-03 01:55:44
  * @LastEditor: BATU1579
- * @LastTime: 2022-09-11 10:51:46
- * @FilePath: \\src\\types\\device.d.ts
+ * @LastTime: 2024-09-23 15:14:13
+ * @FilePath: \\types\\device.d.ts
  * @Description: device 模块
  */
 declare module 'device' {
@@ -88,7 +88,7 @@ declare module 'device' {
         /**
          * @description: Android 系统版本号。例如 '5.0' , '7.1.1' 。
          */
-        readonly releases: string;
+        readonly release: string;
 
         /**
          * @description: 产品构建所基于的操作系统。

--- a/types/widget-operation.d.ts
+++ b/types/widget-operation.d.ts
@@ -422,7 +422,7 @@ declare module 'widget-operation' {
              * @param {string} str `className` 要包含的字符串。
              * @return {this} 返回选择器自身以便链式调用。
              */
-            classNameContent(str: string): this;
+            classNameContains(str: string): this;
 
             /**
              * @description: 为当前选择器附加控件 `className` 需要以 `prefix` 开头的筛选条件。
@@ -1646,7 +1646,7 @@ declare module 'widget-operation' {
          * @param {string} str `className` 要包含的字符串。
          * @return {UiSelector} 返回选择器自身以便链式调用。
          */
-        function classNameContent(str: string): UiSelector;
+        function classNameContains(str: string): UiSelector;
 
         /**
          * @description: 创建一个条件为控件 `className` 需要以 `prefix` 开头的选择器。

--- a/types/widget-operation.d.ts
+++ b/types/widget-operation.d.ts
@@ -422,7 +422,7 @@ declare module 'widget-operation' {
              * @param {string} str `className` 要包含的字符串。
              * @return {this} 返回选择器自身以便链式调用。
              */
-            classNameContent(str: string): this;
+            classNameContents(str: string): this;
 
             /**
              * @description: 为当前选择器附加控件 `className` 需要以 `prefix` 开头的筛选条件。
@@ -1646,7 +1646,7 @@ declare module 'widget-operation' {
          * @param {string} str `className` 要包含的字符串。
          * @return {UiSelector} 返回选择器自身以便链式调用。
          */
-        function classNameContent(str: string): UiSelector;
+        function classNameContents(str: string): UiSelector;
 
         /**
          * @description: 创建一个条件为控件 `className` 需要以 `prefix` 开头的选择器。

--- a/types/widget-operation.d.ts
+++ b/types/widget-operation.d.ts
@@ -422,7 +422,7 @@ declare module 'widget-operation' {
              * @param {string} str `className` 要包含的字符串。
              * @return {this} 返回选择器自身以便链式调用。
              */
-            classNameContent(str: string): this;
+            classNameContents(str: string): this;
 
             /**
              * @description: 为当前选择器附加控件 `className` 需要以 `prefix` 开头的筛选条件。

--- a/types/widget-operation.d.ts
+++ b/types/widget-operation.d.ts
@@ -422,7 +422,7 @@ declare module 'widget-operation' {
              * @param {string} str `className` 要包含的字符串。
              * @return {this} 返回选择器自身以便链式调用。
              */
-            classNameContents(str: string): this;
+            classNameContent(str: string): this;
 
             /**
              * @description: 为当前选择器附加控件 `className` 需要以 `prefix` 开头的筛选条件。

--- a/types/widget-operation.d.ts
+++ b/types/widget-operation.d.ts
@@ -422,7 +422,7 @@ declare module 'widget-operation' {
              * @param {string} str `className` 要包含的字符串。
              * @return {this} 返回选择器自身以便链式调用。
              */
-            classNameContents(str: string): this;
+            classNameContent(str: string): this;
 
             /**
              * @description: 为当前选择器附加控件 `className` 需要以 `prefix` 开头的筛选条件。
@@ -1646,7 +1646,7 @@ declare module 'widget-operation' {
          * @param {string} str `className` 要包含的字符串。
          * @return {UiSelector} 返回选择器自身以便链式调用。
          */
-        function classNameContents(str: string): UiSelector;
+        function classNameContent(str: string): UiSelector;
 
         /**
          * @description: 创建一个条件为控件 `className` 需要以 `prefix` 开头的选择器。

--- a/types/widget-operation.d.ts
+++ b/types/widget-operation.d.ts
@@ -1003,6 +1003,11 @@ declare module 'widget-operation' {
             packageName(): string;
 
             /**
+             * @description: 获取控件在父组件中的索引。
+             */
+            indexInParent(): number;
+
+            /**
              * @description: 获取控件的 `className` 属性。
              */
             className(): string;


### PR DESCRIPTION
- 修复 `classNameContains()` 和 `UiSelector.classNameContains()` 方法的拼写错误
- 添加 `UiObject` 中遗漏的 `indexInParent()` 方法

#16